### PR TITLE
feat: add admin update job status API

### DIFF
--- a/src/RecruitAI.API/Controllers/v1/AdminController.cs
+++ b/src/RecruitAI.API/Controllers/v1/AdminController.cs
@@ -580,5 +580,40 @@ namespace RecruitAI.API.Controllers.v1
 				return await _mediator.Send(applicationsQuery);
 			});
 		}
+
+		/// <summary>
+		/// Cập nhật trạng thái công việc (Chỉ Admin)
+		/// </summary>
+		/// <param name="jobId">ID của công việc</param>
+		/// <param name="request">Trạng thái mới</param>
+		/// <returns>Kết quả cập nhật</returns>
+		[HttpPatch("jobs/{jobId}/status")]
+		[Authorize(Policy = "ManageJobs")]
+		[ProducesResponseType(typeof(AdminJobStatusUpdateResponseDto), StatusCodes.Status200OK)]
+		[ProducesResponseType(StatusCodes.Status400BadRequest)]
+		[ProducesResponseType(StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(StatusCodes.Status403Forbidden)]
+		[ProducesResponseType(StatusCodes.Status404NotFound)]
+		public async Task<ActionResult<AdminJobStatusUpdateResponseDto>> UpdateJobStatus(
+			Guid jobId,
+			[FromBody] AdminJobStatusUpdateRequestDto request)
+		{
+			return await ExecuteAsync<AdminJobStatusUpdateResponseDto>(async () =>
+			{
+				var adminId = GetCurrentUserId();
+				if (adminId == null)
+					throw new UnauthorizedAccessException();
+
+				var command = new UpdateJobStatusCommand
+				{
+					JobId = jobId,
+					Status = request.Status,
+					Reason = request.Reason,
+					AdminId = adminId.Value
+				};
+
+				return await _mediator.Send(command);
+			});
+		}
 	}
 }

--- a/src/RecruitAI.Application/Commands/Admin/UpdateJobStatusCommand.cs
+++ b/src/RecruitAI.Application/Commands/Admin/UpdateJobStatusCommand.cs
@@ -1,0 +1,82 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using RecruitAI.Application.Commands.Notifications;
+using RecruitAI.Application.DTOs.Responses.Admin;
+using RecruitAI.Application.Interfaces.Services;
+using RecruitAI.Domain.Enums;
+using RecruitAI.Domain.Exceptions;
+using RecruitAI.Shared.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace RecruitAI.Application.Commands.Admin
+{
+	// UpdateJobStatusCommand.cs
+	public class UpdateJobStatusCommand : IRequest<AdminJobStatusUpdateResponseDto>
+	{
+		public Guid JobId { get; set; }
+		public JobStatus Status { get; set; }
+		public string? Reason { get; set; }
+		public Guid AdminId { get; set; }
+	}
+
+	// UpdateJobStatusCommandHandler.cs
+	public class UpdateJobStatusCommandHandler : IRequestHandler<UpdateJobStatusCommand, AdminJobStatusUpdateResponseDto>
+	{
+		private readonly IUnitOfWork _uow;
+		private readonly ILogger<UpdateJobStatusCommandHandler> _logger;
+		private readonly IAuditLogService _auditLogService;
+		private readonly IMediator _mediator;
+		private readonly IMessageService _msg;
+
+		public async Task<AdminJobStatusUpdateResponseDto> Handle(UpdateJobStatusCommand request, CancellationToken cancellationToken)
+		{
+			var job = await _uow.Jobs.GetByIdAsync(request.JobId, cancellationToken);
+			if (job == null)
+				throw new BusinessException(ErrorCode.ResourceNotFound, _msg.Business("JobNotFound"));
+
+			var oldStatus = job.Status;
+			var oldStatusName = job.Status.ToString();
+
+			job.Status = request.Status;
+			job.UpdatedAt = DateTime.UtcNow;
+
+			await _uow.SaveChangesAsync(cancellationToken);
+
+			await _auditLogService.LogAsync(
+				AuditEntityType.Job,
+				AuditAction.UpdateJob,
+				job.Id.ToString(),
+				job.Title,
+				oldStatusName,
+				job.Status.ToString(),
+				request.Reason ?? $"Status changed by admin",
+				cancellationToken);
+
+			var notification = new CreateNotificationCommand
+			{
+				UserId = job.RecruiterId,
+				Title = _msg.Get("Notification.JobStatusChanged.Title"),
+				Content = string.Format(_msg.Get("Notification.JobStatusChanged.Content"), job.Title, job.Status.ToString()),
+				Type = "job_update",
+				Data = JsonSerializer.Serialize(new { JobId = job.Id, JobTitle = job.Title, OldStatus = oldStatusName, NewStatus = job.Status.ToString() })
+			};
+			await _mediator.Send(notification, cancellationToken);
+
+			return new AdminJobStatusUpdateResponseDto
+			{
+				JobId = job.Id,
+				JobTitle = job.Title,
+				OldStatus = oldStatus,
+				OldStatusName = oldStatusName,
+				NewStatus = job.Status,
+				NewStatusName = job.Status.ToString(),
+				UpdatedAt = job.UpdatedAt.Value,
+				Success = true,
+				Message = _msg.Success("JobStatusUpdated")
+			};
+		}
+	}
+}

--- a/src/RecruitAI.Application/DTOs/Requests/Admin/AdminJobStatusUpdateRequestDto.cs
+++ b/src/RecruitAI.Application/DTOs/Requests/Admin/AdminJobStatusUpdateRequestDto.cs
@@ -1,0 +1,18 @@
+﻿using RecruitAI.Domain.Enums;
+
+namespace RecruitAI.Application.DTOs.Requests.Admin
+{
+	public class AdminJobStatusUpdateRequestDto
+	{
+		/// <summary>
+		/// Trạng thái mới (1:Draft, 2:Published, 3:Closed)
+		/// </summary>
+		public JobStatus Status { get; set; }
+
+		/// <summary>
+		/// Lý do thay đổi (tùy chọn)
+		/// </summary>
+		public string? Reason { get; set; }
+	}
+
+}

--- a/src/RecruitAI.Application/DTOs/Responses/Admin/AdminJobStatusUpdateResponseDto.cs
+++ b/src/RecruitAI.Application/DTOs/Responses/Admin/AdminJobStatusUpdateResponseDto.cs
@@ -1,0 +1,20 @@
+﻿using RecruitAI.Domain.Enums;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecruitAI.Application.DTOs.Responses.Admin
+{
+	public class AdminJobStatusUpdateResponseDto
+	{
+		public Guid JobId { get; set; }
+		public string JobTitle { get; set; } = string.Empty;
+		public JobStatus OldStatus { get; set; }
+		public string OldStatusName { get; set; } = string.Empty;
+		public JobStatus NewStatus { get; set; }
+		public string NewStatusName { get; set; } = string.Empty;
+		public DateTime UpdatedAt { get; set; }
+		public bool Success { get; set; }
+		public string? Message { get; set; }
+	}
+}


### PR DESCRIPTION
- Add UpdateJobStatusCommand and handler
- Add AdminJobStatusUpdateRequestDto and ResponseDto
- Support status change: Draft, Published, Closed
- Auto audit log and notify recruiter
- Endpoint: PATCH /api/v1/admin/jobs/{jobId}/status