### PR TITLE
fix: add Distinct() to recruiter queries to fix pagination total count

### DIFF
--- a/src/RecruitAI.Application/Queries/Applications/GetRecruiterApplicationsQueryHandler.cs
+++ b/src/RecruitAI.Application/Queries/Applications/GetRecruiterApplicationsQueryHandler.cs
@@ -88,9 +88,11 @@ public class GetRecruiterApplicationsQueryHandler : IRequestHandler<GetRecruiter
 			_ => query.OrderByDescending(x => x.AppliedAt)
 		};
 
-		var total = await query.CountAsync(cancellationToken);
+		var distinctQuery = query.Distinct();
 
-		var items = await query
+		var total = await distinctQuery.CountAsync(cancellationToken);
+
+		var items = await distinctQuery
 			.Skip((request.Page - 1) * request.PageSize)
 			.Take(request.PageSize)
 			.ToListAsync(cancellationToken);

--- a/src/RecruitAI.Application/Queries/Recruiters/GetRecruiterCandidatesQueryHandler.cs
+++ b/src/RecruitAI.Application/Queries/Recruiters/GetRecruiterCandidatesQueryHandler.cs
@@ -94,9 +94,11 @@ public class GetRecruiterCandidatesQueryHandler : IRequestHandler<GetRecruiterCa
 				: query.OrderByDescending(x => x.AppliedAt)
 		};
 
-		var total = await query.CountAsync(cancellationToken);
+		var distinctQuery = query.Distinct();
 
-		var items = await query
+		var total = await distinctQuery.CountAsync(cancellationToken);
+
+		var items = await distinctQuery
 			.Skip((request.Page - 1) * request.PageSize)
 			.Take(request.PageSize)
 			.ToListAsync(cancellationToken);


### PR DESCRIPTION
- Add Distinct() before Count() in GetRecruiterApplicationsQueryHandler
- Add Distinct() before Count() in GetRecruiterCandidatesQueryHandler
- Fix issue where total count > actual items due to duplicate records from JOINs